### PR TITLE
Update all fetch calls, add key to PlantCard

### DIFF
--- a/garden-harvest/src/api/calendarAPI.js
+++ b/garden-harvest/src/api/calendarAPI.js
@@ -1,14 +1,5 @@
-//this is where Api calls to the backend specificly for the calendar.
-//it will eventually be merged with the other api calls.
-
-const BASE_URL = 'http://127.0.0.1:8000/api/'
+import axiosInstance from './axiosAPI';
 
 export const fetchAllEvents = async () => {
-  let response = await fetch(`${BASE_URL}calendarEvents/`, {
-    headers: {'Content-Type': 'application/json'},
-    method: 'GET',
-  })
-  let data = await response.json()
-  console.log(data)
-  return data
+  return await axiosInstance.get('calendarEvents/').then(res => res.data)
 }

--- a/garden-harvest/src/api/dashboardAPI.js
+++ b/garden-harvest/src/api/dashboardAPI.js
@@ -1,11 +1,13 @@
+import axiosInstance from './axiosAPI';
+
 const fetchSuggestedPlants = () => {
-  return fetch('http://localhost:8000/api/suggested/')
-    .then((response) => response.json())
+  return axiosInstance.get('suggested/')
+    .then((response) => response.data)
 }
 
 const fetchPlantDetails = (pk) => {
-  return fetch('http://localhost:8000/api/plants/' + pk + '/')
-    .then((response) => response.json())
+  return axiosInstance.get('plants/' + pk + '/')
+    .then((response) => response.data)
 }
 
 export default {

--- a/garden-harvest/src/api/plantAPI.js
+++ b/garden-harvest/src/api/plantAPI.js
@@ -1,17 +1,11 @@
+import axiosInstance from './axiosAPI';
+
 export const fetchPlants = async () => {
-  return fetch('http://localhost:8000/api/suggested/', {
-    headers: {
-      'Content-Type': 'application/json',
-    }
-  }).then(res => res)
+  return axiosInstance.get('suggested/').then(res => res.data)
 }
 
 export const fetchPlantDetails = async (id) => {
-  return fetch(`http://localhost:8000/api/plants/${id}/`, {
-    headers: {
-      'Content-Type': 'application/json',
-    }
-  }).then(res => res)
+  return axiosInstance.get(`plants/${id}/`).then(res => res.data)
 }
 
 export default {

--- a/garden-harvest/src/components/SuggestedPlants.js
+++ b/garden-harvest/src/components/SuggestedPlants.js
@@ -13,9 +13,7 @@ export default function SuggestedPlants() {
         setSuggestedPlants(data);
       })
     },[]);
-  
-  let plants = suggestedPlants.reverse().map(plant => <PlantCard props={plant}/> );
-
+  let plants = suggestedPlants.reverse().map((plant, i) => <PlantCard key={i} props={plant}/> );
 
   return (
     <div className="cardHolder suggestedPlants">


### PR DESCRIPTION
- Updated any regular `fetch()` calls to use our `axiosInstance` so that Auth headers are always attached and responses are always intercepted for 401s, etc.

- Updated `SuggestedPlants.js` suppress an error related to `PlantCard` not having a unique key associated when generating each card inside the `.map()` call.
