### PR TITLE
Add planting form options with fixes to props data

### DIFF
--- a/garden-harvest/src/api/dashboardAPI.js
+++ b/garden-harvest/src/api/dashboardAPI.js
@@ -20,10 +20,26 @@ const fetchAllPlants = () => {
     .then((response) => response.data)
 }
 
+const fetchPlantingOptions = (plantZoneID) => {
+  return axiosInstance.get(`planting-options/${plantZoneID}/`)
+    .then((response) => response.data)
+}
+
+const sendPlantingChoice = (plantZoneID, slotID, date) => {
+  const data = {
+    plant_zone_id: plantZoneID,
+    slot_id: slotID,
+    earliest_date: date
+  }
+  return axiosInstance.post(`addplant/${plantZoneID}/`, data)
+    .then((response) => response.data)
+}
 
 export default {
   fetchSuggestedPlants,
   fetchPlantDetails,
   fetchAllPlants,
-  fetchMyPlants
+  fetchMyPlants,
+  fetchPlantingOptions,
+  sendPlantingChoice
 }

--- a/garden-harvest/src/components/PlantCard.js
+++ b/garden-harvest/src/components/PlantCard.js
@@ -10,7 +10,7 @@ import PlantingForm from "./PlantingForm";
 
 
 export default function PlantCard(props) {
-  const {plant} = props.props
+  const {plant} = props
 
   let commonname = plant.common_name.toLowerCase();
   let common_name = commonname.replace(" ", "_")
@@ -25,10 +25,10 @@ export default function PlantCard(props) {
         </Col>
         <Col className="textCol">
           <Popup modal trigger={<img src={close} className='close' alt='x' />}>
-            <PlantingForm />
+            <PlantingForm {...props} />
           </Popup>
           <Popup modal trigger={<h6 className="common_name" >{plant.common_name} <img src={chevronright} className='chevron' alt='chevron-right' /></h6>}>
-            <PlantDetailPage props={plant.pk + " " + common_name}/>
+            <PlantDetailPage {...props} both={plant.pk + " " + common_name}/>
           </Popup>
           
           <h4 className="scientific_name">{plant.scientific_name}</h4>

--- a/garden-harvest/src/components/PlantDetailPage.js
+++ b/garden-harvest/src/components/PlantDetailPage.js
@@ -9,7 +9,7 @@ import PlantingForm from "./PlantingForm";
 
 
 export default function PlantDetailPage(props) {
-  const both = props.props;
+  const {both} = props;
   let pk = both.split(" ")[0];
   let src = both.split(" ")[1];
   let required = require('../images/' + src + '.jpg');
@@ -34,7 +34,7 @@ export default function PlantDetailPage(props) {
         </Col>
         <Col>
           <Popup modal trigger={<h6 className="common_name" >{plant.common_name} <img src={close} className="close"/></h6>}>
-            <PlantingForm />
+            <PlantingForm {...props} />
           </Popup>
           <h4 className="scientific_name">{plant.scientific_name}</h4>
         </Col>

--- a/garden-harvest/src/components/PlantingForm.js
+++ b/garden-harvest/src/components/PlantingForm.js
@@ -1,34 +1,57 @@
 import React, { useState, useEffect, Component } from "react";
 import { Form, Button } from 'react-bootstrap';
 import './PlantingForm.css'
+import dashboardAPI from '../api/dashboardAPI.js'
 
-export default function PlantingForm() {
+
+export default function PlantingForm(props) {
+  const {pk, plant} = props
+  const [ slotOptions, setSlotOptions ] = useState([])
+  const [ slotIdx, setSlotIdx ] = useState(null)
+
+  useEffect(() => {
+    // axiosFetch that fills in form slot options for user.
+    // http://localhost:8000/api/scheduleplant/2/
+    
+    dashboardAPI.fetchPlantingOptions(pk)
+      .then(resp => setSlotOptions(resp))
+  }, [])
+  
+  const onChange = (idx) => {
+    setSlotIdx(idx)
+  }
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const selectedSlot = slotOptions[slotIdx]
+    // TODO: The backend for Adding a PlantSlot needs to handle this data sent.
+    // dashboardAPI.sendPlantingChoice(pk, selectedSlot.id, selectedSlot.earliest_date)
+    
+    // For now easy/lazy way to refresh all components just to see updates.
+    // TODO: Might replace this with a state setter func passed through props.
+    window.location.reload()
+  };
+
+  let optionFields = slotOptions.map((option, i) => {
+    let {location_description} = option
+    let location = (location_description ? location_description : option.name)
+    return <Form.Check key={i} 
+              type='radio'
+              id='default-radio'
+              label={`${location} - ${option.earliest_date}`}
+              name="slot"
+              value={option.id}
+              onChange={() => onChange(i)}/>
+  })
+
   return(
-
-  <div className='PlantingForm'>
-    <Form.Check 
-      type='radio'
-      id='default-radio'
-      label='description of Slot 1'
-    />
-    <Form.Check 
-      type='radio'
-      id='default-radio'
-      label='description of Slot 2'
-    />
-    <Form.Check 
-      type='radio'
-      id='default-radio'
-      label='description of Slot 3'
-    />
-    <Form.Check 
-      type='radio'
-      id='default-radio'
-      label='description of Slot 4'
-    />
-    <Button type="submit" className="mb-2" variant="outline-secondary">
-        Plant Here
-    </Button>
-  </div>
+    <div className='PlantingForm'>
+      <Form method="POST" onSubmit={(e) => onSubmit(e)}>
+        {optionFields}
+        <Button type="submit" className="mb-2" variant="outline-secondary">
+            Plant Here
+        </Button>
+      </Form>
+    </div>
   );
 }

--- a/garden-harvest/src/components/SuggestedPlants.js
+++ b/garden-harvest/src/components/SuggestedPlants.js
@@ -3,7 +3,7 @@ import dashboardAPI from '../api/dashboardAPI.js'
 import PlantCard from './PlantCard'
 
 export default function SuggestedPlants() {
-  
+
   let [suggestedPlants, setSuggestedPlants] = useState([]);
 
   useEffect(()=> {
@@ -13,7 +13,8 @@ export default function SuggestedPlants() {
         setSuggestedPlants(data);
       })
     },[]);
-  let plants = suggestedPlants.reverse().map((plant, i) => <PlantCard key={i} props={plant}/> );
+  
+  let plants = suggestedPlants.reverse().map((plant, i) => <PlantCard key={i} {...plant}/> );
 
   return (
     <div className="cardHolder suggestedPlants">


### PR DESCRIPTION
- Add API route to GET planting options before POST
- Add API route to POST but it remains commented out until the backend is fixed up for POSTing a plant in a future commit.
- Fix a few components passing `props.props` used the spread operator and destructuring instead.