### PR TITLE
Fix the props issue causing search error

### DIFF
--- a/garden-harvest/src/components/AllPlants.js
+++ b/garden-harvest/src/components/AllPlants.js
@@ -22,10 +22,10 @@ export default function AllPlants(props) {
     
   let plants = allPlants.reverse().map((plant, i) => {
     if(name === ''){
-      return <PlantCard key={i} props={{plant}}/>
+      return <PlantCard key={i} plant={plant} />
     }else{
       if(plant.common_name.toLowerCase().includes(name)){
-        return <PlantCard key={i} props={{plant}}/>
+        return <PlantCard key={i} plant={plant} />
       }
     }
   } );

--- a/garden-harvest/src/components/MyPlants.js
+++ b/garden-harvest/src/components/MyPlants.js
@@ -13,7 +13,8 @@ export default function MyPlants() {
         setMyPlants(data);
       })
   }, []);
-  let plants = myPlants.reverse().map((plant, i) => <PlantCard key={i} props={plant}/>);
+  
+  let plants = myPlants.reverse().map((plant, i) => <PlantCard key={i} {...plant}/>);
 
   if (plants.length === 0) {
     plants = <h4>You haven't added any plants to your garden yet.</h4>


### PR DESCRIPTION
This should fix what I broke when I pushed fixes to what PlantCard expects for `props` it broke the search UI. Should be able to search now without the page disappearing and getting a dark screen.