### PR TITLE
Add ability to delete from MyPlants card

### DIFF
--- a/garden-harvest/src/api/dashboardAPI.js
+++ b/garden-harvest/src/api/dashboardAPI.js
@@ -35,11 +35,17 @@ const sendPlantingChoice = (plantZoneID, slotID, date) => {
     .then((response) => response.data)
 }
 
+const removeMyPlant = (plantSlotID) => {
+  return axiosInstance.delete(`deleteplant/${plantSlotID}/`)
+    .then((response) => response.data)
+}
+
 export default {
   fetchSuggestedPlants,
   fetchPlantDetails,
   fetchAllPlants,
   fetchMyPlants,
   fetchPlantingOptions,
-  sendPlantingChoice
+  sendPlantingChoice,
+  removeMyPlant
 }

--- a/garden-harvest/src/components/MyPlants.js
+++ b/garden-harvest/src/components/MyPlants.js
@@ -14,7 +14,7 @@ export default function MyPlants() {
       })
   }, []);
 
-  let plants = myPlants.reverse().map((plant, i) => <PlantCard key={i} {...plant}/>);
+  let plants = myPlants.reverse().map((plant, i) => <PlantCard key={i} {...plant} canDelete={true}/>);
 
   if (plants.length === 0) {
     plants = <h4>You haven't added any plants to your garden yet.</h4>

--- a/garden-harvest/src/components/PlantCard.js
+++ b/garden-harvest/src/components/PlantCard.js
@@ -7,16 +7,23 @@ import seedingtag from '../image_SVG_files/seeding-tag.svg';
 import PlantDetailPage from "./PlantDetailPage";
 import Popup from "reactjs-popup";
 import PlantingForm from "./PlantingForm";
+import dashboardAPI from "../api/dashboardAPI";
 
 
 export default function PlantCard(props) {
-  const {plant} = props
+  const {plant, plant_slot_id} = props
+  const canDelete = (props.canDelete ? props.canDelete : false)
 
   let commonname = plant.common_name.toLowerCase();
   let common_name = commonname.replace(" ", "_")
   common_name = common_name.replace(" ", "_")
   let source = require('../images/' + common_name + '.jpg');
   
+  const handleDelete = (plantSlotID) => {
+    dashboardAPI.removeMyPlant(plantSlotID)
+      .then(resp => window.location.reload())
+  }
+
   return (
     <div className="plantCard">
       <Row>
@@ -24,9 +31,18 @@ export default function PlantCard(props) {
           <img src={source} className='photo' alt='common_name' /> 
         </Col>
         <Col className="textCol">
-          <Popup modal trigger={<img src={close} className='close' alt='x' style={{position: 'absolute', right: '15px', zIndex: '50'}}/>}>
-            <PlantingForm {...props} />
-          </Popup>
+          {(canDelete
+            ? 
+            <span>
+              <img src={close} onClick={(e) => handleDelete(plant_slot_id)} className='close' alt='x' style={{position: 'absolute', right: '15px', zIndex: '50'}}/>
+            </span>
+            : 
+            <Popup modal trigger={<img src={close} className='close' alt='+' style={{position: 'absolute', right: '15px', zIndex: '50'}}/>}>
+              <PlantingForm {...props} />
+            </Popup>
+          )}
+          
+          
           <Popup modal trigger={<h6 className="common_name" >{plant.common_name} <img src={chevronright} className='chevron' alt='chevron-right' /></h6>}>
             <PlantDetailPage {...props} both={plant.pk + " " + common_name}/>
           </Popup>


### PR DESCRIPTION
Adding the ability to delete using the X only from a  My Plants card on any given Plant Card.

Set a conditional props to perform a conditional render of the PlantCard section for deleting since PlantCard is re-used across My Plants, Suggested, and All Plants. Deleting should only occur from the My Plants otherwise the same positioned icon on Suggested should expand a Popup instead of performing an onClick delete. 

Didn't bother with passing set state function through props, we are reloading the page on delete too. Not ideal, just going for working functionality. If the instructors let us throw in a few more touchups we can properly handle this.